### PR TITLE
fix : paymoney가 null인경우 에러발생 수정

### DIFF
--- a/src/main/java/com/github/commerce/entity/User.java
+++ b/src/main/java/com/github/commerce/entity/User.java
@@ -73,7 +73,7 @@ public class User {
     }
 
     public PayMoney getPayMoneyByUserId(){
-        return payMoney.stream().max(Comparator.comparing(PayMoney::getId)).orElse(null);
+        return payMoney.stream().max(Comparator.comparing(PayMoney::getId)).orElseGet(PayMoney::new);
     }
 
 


### PR DESCRIPTION
- getInfo API를 사용하여 유저의 정보를 조회 시 500에러 발생
 -  신규가입시 payMoney가 비어있는데 호출하여 발생하는 에러였습니다.
 - 기존 : payMoney 중 최대값 가져오거나 없는 경우 null 반환으로 로직이 짜여져 있었는데 기본생성자를 사용하여 새로운 객체를 생성하여 반환 해주게  하여 오류 잡았습니다.