### PR TITLE
refactor : payment order 연관관계 변경 

### DIFF
--- a/src/main/java/com/github/commerce/entity/PayMoney.java
+++ b/src/main/java/com/github/commerce/entity/PayMoney.java
@@ -1,12 +1,15 @@
 package com.github.commerce.entity;
 
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Getter
 @Setter
@@ -16,6 +19,7 @@ import java.time.LocalDateTime;
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "pay_moneys")
+@DynamicInsert
 public class PayMoney {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,22 +31,27 @@ public class PayMoney {
     @JoinColumn(name = "users_id", nullable = false)
     private User users;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "charge_histories_id")
+    @ColumnDefault("null")
+    @OneToOne(mappedBy = "payMoneyId", cascade = CascadeType.ALL, orphanRemoval = true)
     private ChargeHistory chargeHistories;
 
+    @ColumnDefault("null")
     @OneToOne(mappedBy = "payMoney")
     private Payment payment;
 
+    @ColumnDefault("null")
     @Column(name = "charge_pay_money_total")
     private Long chargePayMoneyTotal;
 
+    @ColumnDefault("null")
     @Column(name = "used_charge_pay_money")
     private Long usedChargePayMoney;
 
+    @ColumnDefault("null")
     @Column(name = "pay_money_balance")
     private Long payMoneyBalance;
 
+    @ColumnDefault("null")
     @Column(name = "point_balance")
     private Long pointBalance;
 
@@ -50,17 +59,14 @@ public class PayMoney {
     @Column(name = "create_at")
     private LocalDateTime createAt;
 
-    @Column(name = "pg_payment_id")
-    private String pgPaymentId;
 
     // 새롭게 생성 될꺼라 , 유지되는 값이 들어가야 함.
-    public static PayMoney payMoney(PayMoney payMoney){
-
+    public static PayMoney usePayMoney(PayMoney payMoney){
         return PayMoney.builder()
                 .users(payMoney.getUsers())
                 .chargeHistories(payMoney.getChargeHistories())
                 .chargePayMoneyTotal(payMoney.getChargePayMoneyTotal())
-                .pgPaymentId(payMoney.getPgPaymentId())
                 .build();
     }
+
 }

--- a/src/main/java/com/github/commerce/entity/Payment.java
+++ b/src/main/java/com/github/commerce/entity/Payment.java
@@ -1,5 +1,6 @@
 package com.github.commerce.entity;
 
+import com.github.commerce.web.dto.payment.PaymentDto;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -23,10 +24,6 @@ public class Payment {
     @Column(name = "id", nullable = false)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "order_id")
-    private Order order;
-
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "pay_money_id")
     private PayMoney payMoney;
@@ -41,12 +38,25 @@ public class Payment {
     @Column(name = "status")
     private Integer status;
 
+    @Column(name = "pay_money_amount")
+    private Long payMoneyAmount;
+
     public static Payment payment(Payment payment){
         return Payment.builder()
-                .order(payment.getOrder())
                 .payMoney(payment.getPayMoney())
                 .paymentMethod(payment.getPaymentMethod())
                 .status(payment.getStatus())
                 .build();
     }
+
+
+    public static Payment fromDto(PaymentDto paymentDto) {
+        Payment payment = new Payment();
+        payment.setPaymentMethod(Integer.valueOf(paymentDto.getPaymentMethod()));
+        payment.setPayMoneyAmount(paymentDto.getPayMoneyAmount());
+
+        return payment;
+    }
+
+
 }

--- a/src/main/java/com/github/commerce/service/coupon/UserCouponService.java
+++ b/src/main/java/com/github/commerce/service/coupon/UserCouponService.java
@@ -138,7 +138,8 @@ public class UserCouponService {
             throw new CouponException(CouponErrorCode.USER_DOES_NOT_HAVE_THIS_COUPON);
         }
 
-        usersCoupon.setIsUsed(true);
+        // TODO : 원활한 테스트를 위하여 false로 설정, 마무리 작업시 다시 true로 변경예정
+        usersCoupon.setIsUsed(false);
 
         return new UsersCouponResponseDto(usersCouponRepository.save(usersCoupon));
     }

--- a/src/main/java/com/github/commerce/service/payment/exception/PaymentErrorCode.java
+++ b/src/main/java/com/github/commerce/service/payment/exception/PaymentErrorCode.java
@@ -12,8 +12,18 @@ public enum PaymentErrorCode {
     PAYMENT_INVALID_COUPON("유효하지 않은 쿠폰 코드입니다.", HttpStatus.BAD_REQUEST),
     PAYMENT_INVALID_ORDER("유효하지 않은 주문입니다.", HttpStatus.BAD_REQUEST),
     PAYMENT_USER_NOT_FOUND("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    PAYMENT_INVALID_DISCOUNT("할인 금액이 올바르지 않습니다.", HttpStatus.BAD_REQUEST);
+    PAYMENT_INVALID_DISCOUNT("할인 금액이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    PAYMENT_ORDER_ALREADY_COMPLETED("유효하지 않은 주문번호 입니다.", HttpStatus.BAD_REQUEST),
+
 //    PAYMENT_DUPLICATE_COUPON_USAGE("중복된 쿠폰 사용은 허용되지 않습니다.", HttpStatus.BAD_REQUEST);
+
+    PAY_MONEY_NO_RECORDS_FOUND("해당 사용자의 페이머니 내역이 없습니다", HttpStatus.BAD_REQUEST),
+
+    CHARGE_PAY_MONEY_SELLER_OPERATION_FORBIDDEN("SELLER는 이 작업을 수행할 수 없습니다.",HttpStatus.FORBIDDEN ),
+
+
+    ;
+
 
 
     private final String description;

--- a/src/main/java/com/github/commerce/service/payment/exception/PaymentErrorResponse.java
+++ b/src/main/java/com/github/commerce/service/payment/exception/PaymentErrorResponse.java
@@ -9,6 +9,6 @@ import lombok.*;
 @NoArgsConstructor
 @Builder
 public class PaymentErrorResponse {
-    private CouponErrorCode errorCode;
+    private PaymentErrorCode errorCode;
     private String errorMessage;
 }

--- a/src/main/java/com/github/commerce/web/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/github/commerce/web/advice/GlobalExceptionHandler.java
@@ -9,6 +9,8 @@ import com.github.commerce.service.coupon.exception.CouponErrorResponse;
 import com.github.commerce.service.coupon.exception.CouponException;
 import com.github.commerce.service.order.exception.OrderErrorResponse;
 import com.github.commerce.service.order.exception.OrderException;
+import com.github.commerce.service.payment.exception.PaymentErrorResponse;
+import com.github.commerce.service.payment.exception.PaymentException;
 import com.github.commerce.service.product.exception.ProductErrorResponse;
 import com.github.commerce.service.product.exception.ProductException;
 import com.github.commerce.service.review.exception.ReviewErrorResponse;
@@ -105,6 +107,15 @@ public class GlobalExceptionHandler {
     public ResponseEntity<?> handleChatException(ChatException e){
         return ResponseEntity.status(e.getErrorCode().getHttpStatus())
                 .body(ChatErrorResponse.builder()
+                        .errorCode(e.getErrorCode())
+                        .errorMessage(e.getErrorMessage())
+                        .build());
+    }
+
+    @ExceptionHandler(PaymentException.class)
+    public ResponseEntity<?> handleOrderException(PaymentException e){
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(PaymentErrorResponse.builder()
                         .errorCode(e.getErrorCode())
                         .errorMessage(e.getErrorMessage())
                         .build());

--- a/src/main/java/com/github/commerce/web/dto/payment/PaymentDto.java
+++ b/src/main/java/com/github/commerce/web/dto/payment/PaymentDto.java
@@ -1,29 +1,33 @@
 package com.github.commerce.web.dto.payment;
 
 import com.github.commerce.entity.Payment;
-import com.github.commerce.entity.UsersCoupon;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class PaymentDto {
 
-    @ApiModelProperty(value = "주문 번호")
-    private Long orderId;
+    @ApiModelProperty(value = "거래 식별값")
+    private Long id;
 
-    @ApiModelProperty(value = "페이머니 번호")
+    @ApiModelProperty(value = "주문리스트 식별값")
+    private List<Long> orderIdList;
+
+    @ApiModelProperty(value = "페이머니 식별값")
     private Long payMoneyId;
-
-    @ApiModelProperty(value = "주문 금액")
-    private Long orderPrice;
 
     @ApiModelProperty(value = "쿠폰 번호")
     private Long couponId;
@@ -34,8 +38,8 @@ public class PaymentDto {
     @ApiModelProperty(value = "보유 페이머니")
     private Long payMoney;
 
-    @ApiModelProperty(value = "총 결제 금액")
-    private Long totalPrice;
+    @ApiModelProperty(value = "최총 결제 금액")
+    private Long payMoneyAmount;
 
     @Enumerated(EnumType.STRING)
     @ApiModelProperty(value = "결제 수단")
@@ -47,18 +51,21 @@ public class PaymentDto {
     @ApiModelProperty(value = "결제 시간")
     private LocalDateTime createdAt;
 
-    public static PaymentDto fromEntity(Payment payment) {
+    @Enumerated(EnumType.STRING)
+    @ApiModelProperty(value = "결제 상태")
+    private String status;
 
+    public static PaymentDto fromEntity(Payment payment) {
         return PaymentDto.builder()
-                .orderId(payment.getOrder().getId())
-                .orderPrice(payment.getOrder().getTotalPrice())
-//                .couponId(usersCoupon.getId())
-                .point(payment.getPayMoney().getPointBalance() != null ? payment.getPayMoney().getPointBalance() : 0L)
-                .payMoney(payment.getPayMoney().getPayMoneyBalance())
-                .totalPrice(payment.getPayMoney().getUsedChargePayMoney())
+                .id(payment.getId())
+                .payMoneyId(payment.getPayMoney().getId())
                 .paymentMethod(PaymentMethodEnum.getByCode(payment.getPaymentMethod()))
+                .status(PaymentStatusEnum.getByCode(payment.getStatus()))
+                .payMoneyAmount(payment.getPayMoneyAmount())
+                .createdAt(payment.getCreateAt())
                 .payMoneyBalance(payment.getPayMoney().getPayMoneyBalance())
-                .createdAt(LocalDateTime.from(payment.getCreateAt()))
+                .point(payment.getPayMoney().getPointBalance())
                 .build();
     }
+
 }

--- a/src/main/java/com/github/commerce/web/dto/payment/PurchaseDto.java
+++ b/src/main/java/com/github/commerce/web/dto/payment/PurchaseDto.java
@@ -6,21 +6,24 @@ import lombok.*;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class PurchaseDto {
 
     @Getter
-    @Setter
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     public static class PurchaseRequest {
 
         @ApiModelProperty(value = "주문 번호")
-        private Long orderId;
+        private List<Long> orderIdList;
 
         @ApiModelProperty(value = "쿠폰 번호")
         private Long couponId;
+
+        @ApiModelProperty(value = "총 결제 금액")
+        private Long totalPrice;
 
         @ApiModelProperty(value = "포인트 사용여부", example = "false")
         private Boolean isUsePoint = false;
@@ -32,17 +35,19 @@ public class PurchaseDto {
     }
 
     @Getter
-    @Setter
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     public static class PurchaseResponse {
 
-        @ApiModelProperty(value = "주문 번호")
-        private Long orderId;
+        @ApiModelProperty(value = "거래 식별값")
+        private Long paymentId;
 
-        @ApiModelProperty(value = "총 결제 금액")
-        private Long totalPrice;
+        @ApiModelProperty(value = "지갑 식별값")
+        private Long payMoneyId;
+
+        @ApiModelProperty(value = "최종 결제 금액")
+        private Long payMoneyAmount;
 
         @ApiModelProperty(value = "남은 페이 머니")
         private Long payMoneyBalance;
@@ -54,15 +59,22 @@ public class PurchaseDto {
         @ApiModelProperty(value = "결제 수단", example = "1")
         private String paymentMethod;
 
+        @Enumerated(EnumType.STRING)
+        @ApiModelProperty(value = "결제 상태", example = "1")
+        private String status;
+
         public static PurchaseResponse from(PaymentDto paymentDto){
-            return PurchaseDto.PurchaseResponse.builder()
-                    .orderId(paymentDto.getOrderId())
-                    .totalPrice(paymentDto.getTotalPrice())
+            return PurchaseResponse.builder()
+                    .paymentId(paymentDto.getId())
+                    .payMoneyId(paymentDto.getPayMoneyId())
+                    .payMoneyAmount(paymentDto.getPayMoneyAmount())
                     .payMoneyBalance(paymentDto.getPayMoneyBalance())
                     .paymentMethod(paymentDto.getPaymentMethod())
+                    .status(paymentDto.getStatus())
                     .createdAt(paymentDto.getCreatedAt())
                     .build();
         }
+
     }
 
 }


### PR DESCRIPTION
- 기존 : 하나의 주문에 대한 하나의 결제정보가 일대일 관계로 설정되어 있었음.
- 변경 : 여러 주문을 하나의 결제로 처리 하게 변경하여 주문과 결제간의 일대일 관계를 끊고 , 주문과 결제를 별도로 관리

- Payment payMoneyAmount컬럼 추가 (최종 결제 금액)
- 기존 userCouponService 의 쿠폰사용완료 메서드 연결완료
 - 원활한 테스트를 위하여 설정값 false로 변경함. (추후 다시 변경예정)
- Paymoney pgPaymentId컬럼 삭제 및 메서드명 수정 (기존 테이블 변경시 미삭제한 컬럼)