### PR TITLE
feat : 포인트내역조회 추가 

### DIFF
--- a/src/main/java/com/github/commerce/entity/PayMoney.java
+++ b/src/main/java/com/github/commerce/entity/PayMoney.java
@@ -1,7 +1,6 @@
 package com.github.commerce.entity;
 
 import lombok.*;
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -9,7 +8,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 @Getter
 @Setter
@@ -51,7 +49,7 @@ public class PayMoney {
 
     @CreatedDate
     @Column(name = "create_at")
-    private LocalDateTime createAt;
+    private LocalDateTime createdAt;
 
 
     // 새롭게 생성 될꺼라 , 유지되는 값이 들어가야 함.

--- a/src/main/java/com/github/commerce/entity/Payment.java
+++ b/src/main/java/com/github/commerce/entity/Payment.java
@@ -6,8 +6,6 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
-import javax.validation.constraints.Size;
-import java.time.Instant;
 import java.time.LocalDateTime;
 
 @Getter
@@ -33,7 +31,7 @@ public class Payment {
 
     @CreatedDate
     @Column(name = "create_at")
-    private LocalDateTime createAt;
+    private LocalDateTime createdAt;
 
     @Column(name = "status")
     private Integer status;

--- a/src/main/java/com/github/commerce/entity/PointHistory.java
+++ b/src/main/java/com/github/commerce/entity/PointHistory.java
@@ -1,6 +1,8 @@
 package com.github.commerce.entity;
 
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -12,6 +14,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "point_histories")
 public class PointHistory {
     @Id
@@ -21,7 +24,7 @@ public class PointHistory {
 
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "pay_money_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false)
     private PayMoney payMoney;
 
     @Column(name = "earned_point")
@@ -30,8 +33,9 @@ public class PointHistory {
     @Column(name = "used_point")
     private Long usedPoint;
 
+    @CreatedDate
     @Column(name = "create_at")
-    LocalDateTime createAt;
+    private LocalDateTime createdAt;
 
     @Column(name = "status")
     private Integer status;

--- a/src/main/java/com/github/commerce/repository/payment/PayMoneyRepository.java
+++ b/src/main/java/com/github/commerce/repository/payment/PayMoneyRepository.java
@@ -17,4 +17,6 @@ public interface PayMoneyRepository extends JpaRepository<PayMoney, Long> {
     Optional<PayMoney> findByUsersId(Long userId);
 
     List<PayMoney> findAllByUsersId(Long userId);
+
+    List<PayMoney> findAllByUsersIdOrderByCreatedAtDesc(Long userId);
 }

--- a/src/main/java/com/github/commerce/repository/payment/PointHistoryRepository.java
+++ b/src/main/java/com/github/commerce/repository/payment/PointHistoryRepository.java
@@ -4,6 +4,10 @@ import com.github.commerce.entity.PointHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PointHistoryRepository extends JpaRepository<PointHistory,Long> {
+
+    List<PointHistory> findAllByPayMoneyUsersId(Long userId);
 }

--- a/src/main/java/com/github/commerce/service/payment/PayMoneyService.java
+++ b/src/main/java/com/github/commerce/service/payment/PayMoneyService.java
@@ -1,10 +1,7 @@
 package com.github.commerce.service.payment;
 
 import com.github.commerce.entity.PayMoney;
-import com.github.commerce.repository.order.OrderRepository;
 import com.github.commerce.repository.payment.PayMoneyRepository;
-import com.github.commerce.repository.payment.PaymentRepository;
-import com.github.commerce.repository.user.UserRepository;
 import com.github.commerce.web.dto.payment.GetPayMoneyDto;
 import com.github.commerce.web.dto.payment.PayMoneyDto;
 import lombok.RequiredArgsConstructor;
@@ -41,7 +38,7 @@ public class PayMoneyService {
                     .chargePayMoney(payMoney.getChargePayMoneyTotal())
                     .point(payMoneyDto.getPointBalance())
                     .payMoneyBalance(payMoneyBalance)
-                    .createAt(payMoneyDto.getCreateAt())
+                    .createAt(payMoneyDto.getCreatedAt())
                     .build();
 
             responseList.add(response);

--- a/src/main/java/com/github/commerce/service/payment/PointHistoryService.java
+++ b/src/main/java/com/github/commerce/service/payment/PointHistoryService.java
@@ -1,9 +1,69 @@
 package com.github.commerce.service.payment;
 
+import com.github.commerce.entity.PayMoney;
+import com.github.commerce.entity.PointHistory;
+import com.github.commerce.repository.payment.PayMoneyRepository;
+import com.github.commerce.repository.payment.PointHistoryRepository;
+import com.github.commerce.service.payment.exception.PaymentErrorCode;
+import com.github.commerce.service.payment.exception.PaymentException;
+import com.github.commerce.web.dto.payment.PointHistoryDto;
+import com.github.commerce.web.dto.payment.PointStatusEnum;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class PointHistoryService {
+
+    private final PayMoneyRepository payMoneyRepository;
+    private final PointHistoryRepository pointHistoryRepository;
+
+    @Transactional
+    public void updatePayMoneyAndAddPointHistory(Long userId, Long earnedPoint, Long usedPoint) {
+
+        List<PayMoney> payMoneyList = payMoneyRepository.findAllByUsersIdOrderByCreatedAtDesc(userId);
+
+        if (payMoneyList.isEmpty()) {
+            // 아직 아무런 포인트 내역이 없는 경우
+            throw new PaymentException(PaymentErrorCode.POINT_HISTORY_NO_RECORDS_FOUND);
+        }
+
+        PayMoney payMoney = payMoneyList.get(0);
+
+        // 포인트 잔액 업데이트
+        Long currentPointBalance = payMoney.getPointBalance();
+        Long newPointBalance = currentPointBalance + earnedPoint - usedPoint;
+        payMoney.setPointBalance(newPointBalance);
+        payMoneyRepository.save(payMoney);
+
+        // 포인트 내역 추가
+        PointHistory pointHistory = new PointHistory();
+        pointHistory.setPayMoney(payMoney);
+        pointHistory.setEarnedPoint(earnedPoint);
+        pointHistory.setUsedPoint(usedPoint);
+
+
+        // 조건에 따라 상태값 설정
+        if (earnedPoint > 0) {
+            pointHistory.setStatus(PointStatusEnum.EARN_POINT.ordinal());
+        } else if (usedPoint < 0) {
+            pointHistory.setStatus(PointStatusEnum.USE_POINT.ordinal());
+        } else{
+            throw new PaymentException(PaymentErrorCode.POINT_HISTORY_INVALID_POINT);
+        }
+
+        pointHistoryRepository.save(pointHistory);
+    }
+
+    public List<PointHistoryDto> getPointHistoryList(Long userId) {
+        List<PointHistory> pointHistoryList = pointHistoryRepository.findAllByPayMoneyUsersId(userId);
+        List<PointHistoryDto> pointHistoryDtoList = pointHistoryList.stream()
+                .map(PointHistoryDto::fromEntity)
+                .collect(Collectors.toList());
+        return pointHistoryDtoList;
+    }
 }

--- a/src/main/java/com/github/commerce/service/payment/exception/PaymentErrorCode.java
+++ b/src/main/java/com/github/commerce/service/payment/exception/PaymentErrorCode.java
@@ -18,7 +18,8 @@ public enum PaymentErrorCode {
 //    PAYMENT_DUPLICATE_COUPON_USAGE("중복된 쿠폰 사용은 허용되지 않습니다.", HttpStatus.BAD_REQUEST);
 
     PAY_MONEY_NO_RECORDS_FOUND("해당 사용자의 페이머니 내역이 없습니다", HttpStatus.BAD_REQUEST),
-
+    POINT_HISTORY_NO_RECORDS_FOUND("해당 사용자의 포인트 내역이 없습니다.", HttpStatus.BAD_REQUEST),
+    POINT_HISTORY_INVALID_POINT("적립 및 사용 포인트가 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
     CHARGE_PAY_MONEY_SELLER_OPERATION_FORBIDDEN("SELLER는 이 작업을 수행할 수 없습니다.",HttpStatus.FORBIDDEN ),
 
 

--- a/src/main/java/com/github/commerce/service/review/ReviewService.java
+++ b/src/main/java/com/github/commerce/service/review/ReviewService.java
@@ -171,7 +171,7 @@ public class ReviewService {
                 PointHistory.builder()
                         .payMoney(validatedPay)
                         .earnedPoint(additionalPoints)
-                        .createAt(LocalDateTime.now())
+                        .createdAt(LocalDateTime.now())
                         .usedPoint(0L)
                         .status(1)
                         .build()

--- a/src/main/java/com/github/commerce/web/controller/payment/PointHistoryController.java
+++ b/src/main/java/com/github/commerce/web/controller/payment/PointHistoryController.java
@@ -1,11 +1,36 @@
 package com.github.commerce.web.controller.payment;
 
+import com.github.commerce.repository.user.UserDetailsImpl;
+import com.github.commerce.service.payment.PointHistoryService;
+import com.github.commerce.web.advice.custom.ResponseDto;
+import com.github.commerce.web.dto.payment.PointHistoryDto;
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @Api(tags = "포인트 내역 API")
 @RestController
+@RequestMapping("/v1/api/points")
 @RequiredArgsConstructor
 public class PointHistoryController {
+
+    private final PointHistoryService pointHistoryService;
+
+    @GetMapping("/history")
+    @ApiOperation("포인트 내역 조회")
+    public ResponseEntity<ResponseDto<List<PointHistoryDto>>> getPointHistoryList(
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        List<PointHistoryDto> pointHistoryDtoList = pointHistoryService.getPointHistoryList(userId);
+        return ResponseEntity.ok(ResponseDto.success(pointHistoryDtoList));
+    }
 }

--- a/src/main/java/com/github/commerce/web/dto/payment/GetPayMoneyDto.java
+++ b/src/main/java/com/github/commerce/web/dto/payment/GetPayMoneyDto.java
@@ -37,7 +37,7 @@ public class GetPayMoneyDto {
                     .chargePayMoney(payMoneyDto.getChargePayMoneyTotal())
                     .point(payMoneyDto.getPointBalance())
                     .payMoneyBalance(payMoneyDto.getPayMoneyBalance())
-                    .createAt(payMoneyDto.getCreateAt())
+                    .createAt(payMoneyDto.getCreatedAt())
                     .build();
         }
 

--- a/src/main/java/com/github/commerce/web/dto/payment/PayMoneyDto.java
+++ b/src/main/java/com/github/commerce/web/dto/payment/PayMoneyDto.java
@@ -41,7 +41,7 @@ public class PayMoneyDto {
     private Long pointBalance;
 
     @ApiModelProperty(value = "거래 시간")
-    private LocalDateTime createAt;
+    private LocalDateTime createdAt;
 
     public static PayMoneyDto fromEntity(PayMoney payMoney) {
         return Optional.ofNullable(payMoney)
@@ -56,7 +56,7 @@ public class PayMoneyDto {
                             .usedPayMoney(p.getUsedChargePayMoney())
                             .payMoneyBalance(p.getPayMoneyBalance())
                             .pointBalance(p.getPointBalance())
-                            .createAt(Optional.ofNullable(p.getCreateAt()).map(LocalDateTime::from).orElse(null))
+                            .createdAt(Optional.ofNullable(p.getCreatedAt()).map(LocalDateTime::from).orElse(null))
                             .build();
                 })
                 .orElse(null);

--- a/src/main/java/com/github/commerce/web/dto/payment/PaymentDto.java
+++ b/src/main/java/com/github/commerce/web/dto/payment/PaymentDto.java
@@ -62,7 +62,7 @@ public class PaymentDto {
                 .paymentMethod(PaymentMethodEnum.getByCode(payment.getPaymentMethod()))
                 .status(PaymentStatusEnum.getByCode(payment.getStatus()))
                 .payMoneyAmount(payment.getPayMoneyAmount())
-                .createdAt(payment.getCreateAt())
+                .createdAt(payment.getCreatedAt())
                 .payMoneyBalance(payment.getPayMoney().getPayMoneyBalance())
                 .point(payment.getPayMoney().getPointBalance())
                 .build();

--- a/src/main/java/com/github/commerce/web/dto/payment/PointStatusEnum.java
+++ b/src/main/java/com/github/commerce/web/dto/payment/PointStatusEnum.java
@@ -1,0 +1,26 @@
+package com.github.commerce.web.dto.payment;
+
+
+public enum PointStatusEnum {
+
+    EARN_POINT(1, "적립"),
+    USE_POINT(2, "사용");
+
+    private final int value;
+    private final String label;
+
+    PointStatusEnum(int value, String label){
+        this.value = value;
+        this.label = label;
+    }
+
+    public static String getByCode(int code){
+        switch(code){
+
+            case 1: return EARN_POINT.label;
+            case 2: return USE_POINT.label;
+
+            default: return EARN_POINT.label;
+        }
+    }
+}

--- a/src/main/java/com/github/commerce/web/dto/payment/TempPayMoneyDto.java
+++ b/src/main/java/com/github/commerce/web/dto/payment/TempPayMoneyDto.java
@@ -26,7 +26,7 @@ public class TempPayMoneyDto {
 
         return TempPayMoneyDto.builder()
                 .payMoneyBalance(payMoney.getPayMoneyBalance())
-                .createAt(LocalDateTime.from(payMoney.getCreateAt()))
+                .createAt(LocalDateTime.from(payMoney.getCreatedAt()))
                 .build();
 
     }


### PR DESCRIPTION
### feat : 포인트내역조회 추가 
- 상세내역없는 기본조회기능 조회가능

- 현재 point가 정상적으로 들어가있는 경우의수가 없어서 조회가 되지 않는 상태
 - pointHistory의 paymoney joinColumn을 userId로 지정하여 userId를 추가 별도로 지정하지않아도 찾아올 수 있게 하였음
- 리뷰작성시 적립이 가능하게 메서드 생성했습니다 .
 - 적립시 pointHistoryService의 updatePayMoneyAndAddPointHistory 사용하시면 됩니다.

### refactor : createdAt 컬럼명 통일 
- 기존 createAt과 createdAt이 통일되어있지 않았었음 , => createdAt으로 통일